### PR TITLE
Add public currentDropNonce

### DIFF
--- a/contracts/MerkleDistributor.abi
+++ b/contracts/MerkleDistributor.abi
@@ -1,0 +1,264 @@
+[
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "token_",
+				"type": "address"
+			},
+			{
+				"internalType": "bytes32",
+				"name": "merkleRoot_",
+				"type": "bytes32"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "index",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			}
+		],
+		"name": "Claimed",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"internalType": "bytes32",
+				"name": "merkleRoot",
+				"type": "bytes32"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "dropNonce",
+				"type": "uint256"
+			}
+		],
+		"name": "newDistribution",
+		"type": "event"
+	},
+	{
+		"inputs": [],
+		"name": "SWIVELMULTISIG",
+		"outputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "dropNonce",
+				"type": "uint256"
+			}
+		],
+		"name": "_merkleRoot",
+		"outputs": [
+			{
+				"internalType": "bytes32",
+				"name": "",
+				"type": "bytes32"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "admin",
+		"outputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "index",
+				"type": "uint256"
+			},
+			{
+				"internalType": "address",
+				"name": "account",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			},
+			{
+				"internalType": "bytes32[]",
+				"name": "merkleProof",
+				"type": "bytes32[]"
+			}
+		],
+		"name": "claim",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "currentDropNonce",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "index",
+				"type": "uint256"
+			},
+			{
+				"internalType": "uint256",
+				"name": "dropNonce",
+				"type": "uint256"
+			}
+		],
+		"name": "isClaimed",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "from",
+				"type": "address"
+			},
+			{
+				"internalType": "address",
+				"name": "to",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			},
+			{
+				"internalType": "bytes32",
+				"name": "merkleRoot_",
+				"type": "bytes32"
+			}
+		],
+		"name": "iterateDistribution",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"name": "merkleRoot",
+		"outputs": [
+			{
+				"internalType": "bytes32",
+				"name": "",
+				"type": "bytes32"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "bool",
+				"name": "b",
+				"type": "bool"
+			}
+		],
+		"name": "pause",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "paused",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "token",
+		"outputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	}
+]

--- a/contracts/MerkleDistributor.sol
+++ b/contracts/MerkleDistributor.sol
@@ -10,6 +10,8 @@ contract MerkleDistributor is IMerkleDistributor {
     address public immutable override admin;
     // Must set and replace msg.sender as admin
     address public immutable SWIVELMULTISIG = address(0);
+    uint256 public currentDropNonce;
+    // 
     bool public paused;
     // This is a packed array of booleans.
     mapping(uint256 => bytes32) public merkleRoot;
@@ -34,13 +36,8 @@ contract MerkleDistributor is IMerkleDistributor {
     /// @param from The address of the wallet containing tokens to distribute
     /// @param to The address that will receive any currently remaining distributions (will normally be the same as from)
     /// @param amount The amount of tokens in the new distribution
-    /// @param dropNonce The nonce of the drop that is currently being overwritten
     /// @param merkleRoot_ The merkle root associated with the new distribution
-    function iterateDistribution(address from, address to, uint256 amount, bytes32 merkleRoot_, uint256 dropNonce) external override onlyAdmin(admin) {
-        require(!isCancelled[dropNonce], 'Drop nonce already cancelled');
-        
-        // unpause redemptions
-        pause(false);
+    function iterateDistribution(address from, address to, uint256 amount, bytes32 merkleRoot_) external override onlyAdmin(admin) {      
         
         // remove current token balance
         IERC20 _token = IERC20(token);
@@ -51,12 +48,16 @@ contract MerkleDistributor is IMerkleDistributor {
         _token.transferFrom(from, address(this), amount);
         
         // cancel previous drop nonce / previous distribution
-        isCancelled[dropNonce] = true;
+        isCancelled[currentDropNonce] = true;
         
         // add the new distribution's merkleRoot
-        merkleRoot[(dropNonce+1)] = merkleRoot_;
+        merkleRoot[(currentDropNonce+1)] = merkleRoot_;
 
-        emit newDistribution(merkleRoot_, (dropNonce+1));
+        // unpause redemptions
+        pause(false);
+
+        // emit distribution event
+        emit newDistribution(merkleRoot_, (currentDropNonce+1));
     }
 
     function isClaimed(uint256 index, uint256 dropNonce) public view override returns (bool) {
@@ -73,16 +74,16 @@ contract MerkleDistributor is IMerkleDistributor {
         claimedBitMap[dropNonce][claimedWordIndex] = claimedBitMap[dropNonce][claimedWordIndex] | (1 << claimedBitIndex);
     }
 
-    function claim(uint256 index, address account, uint256 amount, bytes32[] calldata merkleProof, uint256 dropNonce) external unpaused() override {
-        require(!isClaimed(index, dropNonce), 'MerkleDistributor: Drop already claimed.');
-        require(!isCancelled[dropNonce], 'Drop nonce already cancelled');
+    function claim(uint256 index, address account, uint256 amount, bytes32[] calldata merkleProof) external unpaused() override {
+        require(!isClaimed(index, currentDropNonce), 'MerkleDistributor: Drop already claimed.');
+        require(!isCancelled[currentDropNonce], 'Drop nonce already cancelled');
 
         // Verify the merkle proof.
         bytes32 node = keccak256(abi.encodePacked(index, account, amount));
-        require(MerkleProof.verify(merkleProof, merkleRoot[dropNonce], node), 'MerkleDistributor: Invalid proof.');
+        require(MerkleProof.verify(merkleProof, merkleRoot[currentDropNonce], node), 'MerkleDistributor: Invalid proof.');
 
         // Mark it claimed and send the token.
-        _setClaimed(index, dropNonce);
+        _setClaimed(index, currentDropNonce);
         require(IERC20(token).transfer(account, amount), 'MerkleDistributor: Transfer failed.');
 
         emit Claimed(index, account, amount);

--- a/contracts/interfaces/IMerkleDistributor.sol
+++ b/contracts/interfaces/IMerkleDistributor.sol
@@ -10,9 +10,9 @@ interface IMerkleDistributor {
     // Returns true if the index has been marked claimed.
     function isClaimed(uint256 index, uint256 dropNonce) external view returns (bool);
     // Claim the given amount of the token to the given address. Reverts if the inputs are invalid.
-    function claim(uint256 index, address account, uint256 amount, bytes32[] calldata merkleProof, uint256 dropNonce) external;
+    function claim(uint256 index, address account, uint256 amount, bytes32[] calldata merkleProof) external;
     // Allows an admin to overwrite the current distribution with a new one 
-    function iterateDistribution(address from, address to, uint256 amount, bytes32 merkleRoot_, uint256 dropNonce) external;
+    function iterateDistribution(address from, address to, uint256 amount, bytes32 merkleRoot_) external;
     // Allows an admin to pause the current distribution 
     function pause(bool b) external returns (bool);
     // This event is triggered whenever a call to #claim succeeds.


### PR DESCRIPTION
- remove dropNonce param from claim and iterateDistribution
- add currentDropNonce public var
- replace dropNonce param references with currentDropNonce
- remove require in iterateDistribution now that dropNonce is referenced rather than passed